### PR TITLE
Do Not Require 'browser' key for URL Tiles

### DIFF
--- a/src/dock-cli.sh
+++ b/src/dock-cli.sh
@@ -1058,6 +1058,7 @@ _findUrlApp() {
   label="$1"
   url="$2"
   browser="$3"
+  [ -z "$browser" ] && browser="any"
   idx=1
 
   declare -a possible


### PR DESCRIPTION
Currently, if no `browser` key is given for a URL tile (configured an object) an existing app or webloc will not be found; this PR fixes that by defaulting to 'any' for the `$browser` if the given `$browser` is empty.