### PR TITLE
Use Unquoted Path When Resolving

### DIFF
--- a/src/dock-cli.sh
+++ b/src/dock-cli.sh
@@ -625,7 +625,7 @@ function app::adobe::summarize() {
 # @exitcode 1 No Path Found
 function app::paths::exists() {
   local i
-  jq -c '.[]' <<< "$1" | while read i; do
+  jq -r -c '.[]' <<< "$1" | while read i; do
     if [ -e "$i" ]; then
       echo "$i" && return 0
     fi


### PR DESCRIPTION
Currently, when paths are pulled from the `$specialApps` JSON, and checked for existence they may fail due to quoting of the value.  This PR adds the needed `-r` flag to the `jq` call.